### PR TITLE
feat(review): load review items from Firestore via service layer

### DIFF
--- a/lib/models/review.dart
+++ b/lib/models/review.dart
@@ -1,0 +1,39 @@
+
+class Review {
+  final String title;             // Name of the meal
+  final int stars;                // Rating from 1 to 5
+  final String ratingText;        // Formatted rating display string
+  final String reviewText;        // Review content
+  final List<String> tags;        // List of tags like ["Filling"]
+  final bool hasMoreButton;       // Optional UI control
+  final String userId;           // UID of the reviewer
+  final String? imageUrl;         // Optional image URL
+
+
+  Review({
+    required this.title,
+    required this.stars,
+    required this.ratingText,
+    required this.reviewText,
+    required this.tags,
+    required this.userId,
+    this.hasMoreButton = false,
+    this.imageUrl,
+  });
+
+  /// Convert Firestore data map to a Review object
+  factory Review.fromFirestore(Map<String, dynamic> map) {
+    final double rawRating = (map['rating'] ?? 0).toDouble();
+
+    return Review(
+      title: map['meal'] ?? 'Untitled',
+      stars: rawRating.round(),
+      ratingText: '(${rawRating.toStringAsFixed(1)} of 5 Stars)',
+      reviewText: map['reviewText'] ?? '',
+      tags: List<String>.from(map['tags'] ?? []),
+      imageUrl: map['imageUrl'],
+      userId: map['userId'],
+      hasMoreButton: false,
+    );
+  }
+}

--- a/lib/services/review_service.dart
+++ b/lib/services/review_service.dart
@@ -1,0 +1,18 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/review.dart';
+
+class ReviewService {
+  /// Fetches all reviews from Firestore and converts them to Review objects
+  static Future<List<Review>> fetchAllReviews() async {
+    try {
+      final snapshot = await FirebaseFirestore.instance.collection('reviews').get();
+      return snapshot.docs.map((doc) {
+        final data = doc.data();
+        return Review.fromFirestore(data);
+      }).toList();
+    } catch (e) {
+      print("Error fetching reviews: $e");
+      return [];
+    }
+  }
+}

--- a/lib/widgets/review_card.dart
+++ b/lib/widgets/review_card.dart
@@ -1,65 +1,57 @@
 import 'package:flutter/material.dart';
 import 'review_item.dart';
+import '../models/review.dart';
+import '../services/review_service.dart';
 
 class ReviewCard extends StatelessWidget {
   const ReviewCard({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8.0),
-      ),
-      child: Padding(
-        padding: EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              "This week's reviews:",
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 16.0,
-              ),
+    return FutureBuilder<List<Review>>(
+      // Load reviews using the service layer
+      future: ReviewService.fetchAllReviews(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return Center(child: CircularProgressIndicator());
+        } else if (snapshot.hasError) {
+          return Text('Error: ${snapshot.error}');
+        } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+          return Text('No reviews available.');
+        }
+
+        final reviews = snapshot.data!;
+        return Card(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8.0),
+          ),
+          child: Padding(
+            padding: EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  "This week's reviews:",
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0),
+                ),
+                SizedBox(height: 8.0),
+
+                // Render each review as a ReviewItem
+                for (int i = 0; i < 3; i++) ...[
+                  ReviewItem(
+                    title: reviews[i].title,
+                    stars: reviews[i].stars,
+                    ratingText: reviews[i].ratingText,
+                    reviewText: reviews[i].reviewText,
+                    hasMoreButton: reviews[i].hasMoreButton,
+                  ),
+                  if (i != reviews.length - 1) Divider(),
+                ],
+              ],
             ),
-            SizedBox(height: 8.0),
-            
-            // Review Items - These could be loaded from database later
-            ReviewItem(
-              title: 'Cheese Pizza',
-              stars: 2,
-              ratingText: '(25.25 of 5 Stars)',
-              reviewText: 'Last Franklin: The pizza was very greasy and a little cold. The crust was also burnt and not enjoyable.',
-              hasMoreButton: true,
-            ),
-            Divider(),
-            
-            ReviewItem(
-              title: 'Spaghetti',
-              stars: 5,
-              ratingText: '(5 of 5 Stars)',
-              reviewText: 'Anthony Hordesky: My spaghetti was great. The noodles were cooked perfectly and the sauce was very flavorful.',
-            ),
-            Divider(),
-            
-            ReviewItem(
-              title: 'Lasagna',
-              stars: 4,
-              ratingText: '(4.5 of 5 Stars)',
-              reviewText: 'Alex Laureano: I was a fan of the lasagna. It was a little saltier than I like, but I would still eat it again.',
-            ),
-            Divider(),
-            
-            ReviewItem(
-              title: 'Mac N\' Cheese',
-              stars: 1,
-              ratingText: '(1 of 5 Stars)',
-              reviewText: 'Ilahao Shu: I liked this dish. The noodles were a good choice for this dish and the cheese used was',
-              hasMoreButton: true,
-            ),
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -348,10 +348,10 @@ packages:
     dependency: transitive
     description:
       name: html
-      sha256: "1fc58edeaec4307368c60d59b7e15b9d658b57d7f3125098b6294153c75337ec"
+      sha256: "9475be233c437f0e3637af55e7702cbbe5c23a68bd56e8a5fa2d426297b7c6c8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.5"
+    version: "0.15.5+1"
   http:
     dependency: transitive
     description:
@@ -620,10 +620,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "3ec7210872c4ba945e3244982918e502fa2bfb5230dff6832459ca0e1879b7ad"
+      sha256: c2c8c46297b5d6a80bed7741ec1f2759742c77d272f1a1698176ae828f8e1a18
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.8"
+    version: "2.4.9"
   shared_preferences_foundation:
     dependency: transitive
     description:


### PR DESCRIPTION
Replace the static review list in ReviewCard with dynamic data loaded from Firestore.

Changes include:
- Created `ReviewService` to encapsulate Firestore query logic for fetching all review documents.
- Introduced `Review` model class to map Firestore data into structured Dart objects.
- Refactored `ReviewCard` to use FutureBuilder and consume data from ReviewService.